### PR TITLE
[ #60 ] Implement Alternative BQ Type 4

### DIFF
--- a/campus_picks/analytics_engine/templates/team_popularity.html
+++ b/campus_picks/analytics_engine/templates/team_popularity.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page_title }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f3f4f6; /* Light gray background */
+        }
+        .card {
+            background-color: #ffffff;
+            border-radius: 0.75rem; /* rounded-xl */
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); /* shadow-md */
+            padding: 1.5rem; /* p-6 */
+            margin-bottom: 1.5rem; /* mb-6 */
+        }
+        th, td {
+            padding: 0.75rem 1rem; /* py-3 px-4 */
+            text-align: left;
+        }
+        th {
+            background-color: #e5e7eb; /* Gray background for table headers */
+            font-weight: 600; /* font-semibold */
+            color: #374151; /* text-gray-700 */
+        }
+        tr:nth-child(even) {
+            background-color: #f9fafb; /* Alternate row color */
+        }
+    </style>
+</head>
+<body class="p-4 sm:p-6 md:p-8">
+    <div class="max-w-4xl mx-auto">
+        <h1 class="text-3xl font-bold text-gray-800 mb-6 text-center">{{ page_title }}</h1>
+
+        <div class="card">
+            <h2 class="text-2xl font-semibold text-gray-700 mb-4">Most Popular Teams by Total Stake</h2>
+            {% if team_popularity %}
+                <div class="overflow-x-auto rounded-lg">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-100">
+                            <tr>
+                                <th class="rounded-tl-lg">Team</th>
+                                <th>Total Stake</th>
+                                <th class="rounded-tr-lg">Number of Bets</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            {% for team in team_popularity %}
+                                <tr>
+                                    <td class="font-medium text-gray-900">{{ team.team__name }}</td>
+                                    <td class="text-gray-700">${{ team.total_stake|floatformat:2 }}</td>
+                                    <td class="text-gray-700">{{ team.num_bets }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <p class="text-gray-600">No betting data available to show team popularity.</p>
+            {% endif %}
+        </div>
+
+        <div class="card">
+            <h2 class="text-2xl font-semibold text-gray-700 mb-4">Teams with Most Bets</h2>
+            {% if team_most_bets %}
+                <div class="overflow-x-auto rounded-lg">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-100">
+                            <tr>
+                                <th class="rounded-tl-lg">Team</th>
+                                <th>Number of Bets</th>
+                                <th class="rounded-tr-lg">Total Stake</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            {% for team in team_most_bets %}
+                                <tr>
+                                    <td class="font-medium text-gray-900">{{ team.team__name }}</td>
+                                    <td class="text-gray-700">{{ team.num_bets }}</td>
+                                    <td class="text-gray-700">${{ team.total_stake|floatformat:2 }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <p class="text-gray-600">No betting data available to show teams with most bets.</p>
+            {% endif %}
+        </div>
+    </div>
+</body>
+</html>

--- a/campus_picks/analytics_engine/urls.py
+++ b/campus_picks/analytics_engine/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("metrics/", views.log_api_metrics, name="metrics"),
     path("runDailyAnalytics/", views.triggerDailyAnalytics, name="analytics"),
     path("productViews/", views.ingest_product_views, name="productViews"),
+    path('dashboard/team-popularity/', views.team_popularity_dashboard, name='team_popularity_dashboard'),
 ]
 
 


### PR DESCRIPTION
This pull request introduces a new feature to display a dashboard for team popularity based on betting activity, including both total stake and the number of bets. The changes span the addition of a new HTML template, a new view function, and updates to the URL configuration and imports.

Closes #60 

### New Feature: Team Popularity Dashboard

* **HTML Template for Dashboard**:
  - Created a new template `team_popularity.html` to display team popularity and betting statistics using a responsive design with Tailwind CSS. The dashboard includes two sections: "Most Popular Teams by Total Stake" and "Teams with Most Bets."

* **New View Function**:
  - Added `team_popularity_dashboard` in `views.py` to calculate and render team popularity data. It uses `Sum` and `Count` annotations to aggregate total stakes and the number of bets for each team.

### Supporting Changes

* **URL Configuration**:
  - Added a new route `/dashboard/team-popularity/` in `urls.py` to serve the team popularity dashboard.

* **Updated Imports**:
  - Imported `Sum` and `Count` from `django.db.models` in `views.py` to support the new view's database queries.